### PR TITLE
remove var usage in lock header

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -57,10 +57,6 @@ jobs:
       with:
         toolchain: nightly-2024-06-10
 
-    - uses: Swatinem/rust-cache@v2
-      with:
-        cache-on-failure: true
-
     - name: Install Circom
       run: |
         CIRCOM_VERSION=2.1.9

--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -79,11 +79,18 @@ jobs:
         VERSION=$(node -p "require('./package.json').version")
         echo "VERSION=$VERSION" >> $GITHUB_ENV
 
+    - name: Setup circom-witnesscalc
+      run: |
+        cd .. && git clone https://github.com/iden3/circom-witnesscalc.git
+        cd circom-witnesscalc
+        cargo install --path .
+        echo $(which build-circuit)
+
     - name: Build circuits using Makefile
       run: |
         make debug  # Show what will be processed
         make build  # Build the circuits
-    
+
     - name: Create release artifacts
       run: |
         # Get the list of target directories
@@ -91,7 +98,7 @@ jobs:
           if [ -d "$target_dir/artifacts" ]; then
             # Extract the target size from the directory name
             target_size=$(basename "$target_dir")
-            
+
             echo "Creating archive for $target_size"
             # Create zip file for this target size
             ( cd "$target_dir/artifacts" && \

--- a/circuits/http/nivc/lock_header.circom
+++ b/circuits/http/nivc/lock_header.circom
@@ -87,7 +87,9 @@ template FirstStringMatch(dataLen, maxKeyLen) {
         paddedData[dataLen + i] <== 0;
     }
 
-    var matched = 0;
+    signal isMatched[dataLen+1];
+    isMatched[0] <== 0;
+
     var counter = 0;
     component stringMatch[dataLen];
     component hasMatched[dataLen];
@@ -101,13 +103,13 @@ template FirstStringMatch(dataLen, maxKeyLen) {
         stringMatch[idx] = IsEqualArray(maxKeyLen);
         stringMatch[idx].in[0] <== key;
         for (var key_idx = 0 ; key_idx < maxKeyLen ; key_idx++) {
-            isFirstMatchAndInsideBound[idx * maxKeyLen + key_idx] <== (1 - matched) * (1 - isKeyOutOfBounds[key_idx]);
+            isFirstMatchAndInsideBound[idx * maxKeyLen + key_idx] <== (1 - isMatched[idx]) * (1 - isKeyOutOfBounds[key_idx]);
             stringMatch[idx].in[1][key_idx] <== paddedData[idx + key_idx] * isFirstMatchAndInsideBound[idx * maxKeyLen + key_idx];
         }
         hasMatched[idx] = IsEqual();
         hasMatched[idx].in <== [stringMatch[idx].out, 1];
-        matched += hasMatched[idx].out;
-        counter += (1 - matched); // TODO: Off by one? Move before?
+        isMatched[idx+1] <== isMatched[idx] + hasMatched[idx].out;
+        counter += (1 - isMatched[idx+1]); // TODO: Off by one? Move before?
     }
     position <== counter;
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-prover-circuits",
   "description": "ZK Circuits for WebProofs",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
closes #30 

reduces r1cs file size for `http_lock_header` circuit from 1.93G to 43MB by removing var usage in `FirstStringMatch` template.

Note: this doesn't happen with all `vars`, as can be noted here, only happening for iterating `var` accessed again in a separate signal/var.