### PR TITLE
fix: hash circom file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,12 @@ all: build
 # Build target
 .PHONY: build
 build:
+	@set -e;
 	@for circuit in $(CIRCOM_FILES); do \
 		echo "Processing $${circuit}..."; \
 		circom "$${circuit}" --r1cs --wasm -o "$$(dirname $${circuit})/artifacts" -l node_modules; \
 		build-circuit "$${circuit}" "$$(dirname $${circuit})/artifacts/$$(basename $${circuit} .circom).bin" -l node_modules; \
+		echo "====================xxxxxxxxxx===================="; \
 	done
 
 # Clean target

--- a/circuits/utils/hash.circom
+++ b/circuits/utils/hash.circom
@@ -67,7 +67,8 @@ template PoseidonChainer() {
 }
 
 template DataHasher(DATA_BYTES) {
-    assert(DATA_BYTES % 16 == 0);
+    // TODO: add this assert back after witnesscalc supports
+    // assert(DATA_BYTES % 16 == 0);
     signal input in[DATA_BYTES];
     signal output out;
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-prover-circuits",
   "description": "ZK Circuits for WebProofs",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
json extract witnesscalc binary creation failed due to assert in hash circom that uses `%`. witnesscalc currently doesn't support that. 

<img width="934" alt="Screenshot 2024-11-12 at 19 05 47" src="https://github.com/user-attachments/assets/dd4e29db-2f23-46f0-95ff-fe8dbdca73be">

