### PR TITLE
feat: adaptable foldable AES circuit

### DIFF
--- a/circuits/aes-gcm/nivc/aes-gctr-nivc.circom
+++ b/circuits/aes-gcm/nivc/aes-gctr-nivc.circom
@@ -41,14 +41,8 @@ template AESGCTRFOLD(NUM_CHUNKS) {
         }
     }
 
-    
-    var packedPlaintext[NUM_CHUNKS];
-    for(var i = 0 ; i < NUM_CHUNKS ; i++) {
-        packedPlaintext[i] = 0;
-        for(var j = 0 ; j < 16 ; j++) {
-            packedPlaintext[i] += plainText[i][j] * 2**(8*j);
-        }
-    }
+    signal packedPlaintext[NUM_CHUNKS] <== GenericBytePackArray(NUM_CHUNKS, 16)(plainText);
+
     signal hash[NUM_CHUNKS];
     for(var i = 0 ; i < NUM_CHUNKS ; i++) {
         if(i == 0) {

--- a/circuits/aes-gcm/nivc/aes-gctr-nivc.circom
+++ b/circuits/aes-gcm/nivc/aes-gctr-nivc.circom
@@ -40,18 +40,21 @@ template AESGCTRFOLD(NUM_CHUNKS) {
     }
     signal packedCiphertext[NUM_CHUNKS] <== GenericBytePackArray(NUM_CHUNKS, 16)(cipherText);
     signal packedComputedCiphertext[NUM_CHUNKS] <== GenericBytePackArray(NUM_CHUNKS, 16)(computedCipherText);
+    signal packedPlaintext[NUM_CHUNKS] <== GenericBytePackArray(NUM_CHUNKS, 16)(plainText);
 
+    signal plaintext_input_was_zero_chunk[NUM_CHUNKS];
     signal ciphertext_input_was_zero_chunk[NUM_CHUNKS];
+    signal both_input_chunks_were_zero[NUM_CHUNKS];
     signal ciphertext_option[NUM_CHUNKS];
     signal ciphertext_equal_check[NUM_CHUNKS];
     for(var i = 0 ; i < NUM_CHUNKS; i++) {
+            plaintext_input_was_zero_chunk[i] <== IsZero()(packedPlaintext[i]);   
             ciphertext_input_was_zero_chunk[i] <== IsZero()(packedCiphertext[i]);
-            ciphertext_option[i] <== (1 - ciphertext_input_was_zero_chunk[i]) * packedComputedCiphertext[i];
+            both_input_chunks_were_zero[i] <== plaintext_input_was_zero_chunk[i] * ciphertext_input_was_zero_chunk[i];
+            ciphertext_option[i] <== (1 - both_input_chunks_were_zero[i]) * packedComputedCiphertext[i];
             ciphertext_equal_check[i] <== IsEqual()([packedCiphertext[i], ciphertext_option[i]]);
             ciphertext_equal_check[i] === 1;
     }
-
-    signal packedPlaintext[NUM_CHUNKS] <== GenericBytePackArray(NUM_CHUNKS, 16)(plainText);    
     step_out[0] <== AESHasher(NUM_CHUNKS)(packedPlaintext, step_in[0]);
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-prover-circuits",
   "description": "ZK Circuits for WebProofs",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Idea
Basically, we want to be able to provide a padded plaintext input to our NIVC chain. There may be 242 bytes of plaintext, but we will pad to 512.

With previous work (a-la #45), we were able to run the AES circuit 16 times and not actually the full 32 needed to consume the padded ciphertext because when we hash plaintext data, we are doing so by ignoring full 16 byte chunks that are zero (as these indicate padding). Real plaintext won't have that (unless I'm mistaken -- in which case we should pad with -1 or 256 since real plaintext absolutely, certainly, cannot have that).

Now, what we also want to be able to do is potentially do 2 or more AES encryption chunks per fold. However, there is potentially some oddity that would happen in a case where the plaintext was, say 239 bytes and we were folding 2 AES encryption chunks at a time. Namely, it would encrypt the bytes 240-256 as a chunk, even those these are actually all zeros and only appear due to padding and trying to encrypt more than we need. 


## This PR
This PR  solves this problem. We will default to checking that the encryption of plaintext in circuit matches the ciphertext private input chunk by chunk UNLESS both the plaintext and ciphertext chunks input at that point were zero. In that case, it bypasses this check and continues forward.

Furthermore, we selectively only hash the nonzero chunks just like the new DataHasher circuit from #45. 

## Reviewing

PLEASE BE CAREFUL REVIEWING THIS! This is a potential optimization we can use, but this does need some time to be carefully reviewed before I feel comfortable shipping it.

---

Closes #46 