### PR TITLE
feat: Google Cloud Storage bucket uploads

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -120,6 +120,8 @@ jobs:
           if [ -d "$target_dir/artifacts" ]; then
             echo "Creating archive for $size"
             ( cd "$target_dir/artifacts" && \
+              find . -type f -name "*.wasm" -exec bash -c 'mv "$1" "$(dirname "$1")/../"' _ {} \; &&\
+              rm -rf *_js &&\
               zip -r "../../../circom-artifacts-${size}-v${{ env.VERSION }}.zip" . )
           fi
         done
@@ -134,4 +136,4 @@ jobs:
       with:
         name: circom-artifacts-v${{ env.VERSION }}
         path: circom-artifacts-*-v${{ env.VERSION }}.zip
-        retention-days: 5
+        retention-days: 14

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   release:
@@ -16,6 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
+      - uses: "google-github-actions/auth@v2"
+        with:
+          project_id: "web-prover-circuits-fa4cf3"
+          workload_identity_provider: "projects/530011589985/locations/global/workloadIdentityPools/github/providers/web-prover-circuits"
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -72,3 +78,22 @@ jobs:
           body_path: release_notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare artifacts for Google Cloud Storage Bucket
+        run: |
+          # Unzip, then gzip each individual file, delete zip files
+          for zip_file in artifacts/circom-artifacts-*-v${{ env.VERSION }}.zip; do
+            unzip "$zip_file" -d "${zip_file%.zip}"
+            (cd "${zip_file%.zip}" && gzip -7 *)
+          done
+          rm *.zip
+
+      - uses: "google-github-actions/upload-cloud-storage@v2"
+        with:
+          path: "artifacts"
+          destination: "web-prover-circuits.pluto.xyz/${{ github.sha }}"
+          parent: false
+          gzip: false # already gzipped
+          headers: |-
+            content-type: 'application/octet-stream'
+            content-encoding: 'gzip'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,10 +81,10 @@ jobs:
 
       - name: Prepare artifacts for Google Cloud Storage Bucket
         run: |
-          # Unzip, then gzip each individual file, delete zip files
+          # Unzip, then gzip each individual file (but remove .gz suffix), delete zip files
           for zip_file in artifacts/circom-artifacts-*-v${{ env.VERSION }}.zip; do
             unzip "$zip_file" -d "${zip_file%.zip}"
-            (cd "${zip_file%.zip}" && gzip -7 *)
+            (cd "${zip_file%.zip}" && gzip -7 * && for file in *.gz; do mv "$file" "${file%.gz}"; done)
           done
           rm *.zip
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-prover-circuits",
   "description": "ZK Circuits for WebProofs",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Changes in this PR:

* move *.wasm file into parent, delete *_js directory.
* Increase artifact lifespan to 14 days
* Release workflow also uploads to Google Cloud Storage bucket

Files uploaded to Google Cloud Storage bucket are individually gzip'ed with flag `-7` to go with a slightly higher/ better compression at the cost of decompression speed. The gzip default is 6 btw.

Files can be accessed via `https://web-prover-circuits.pluto.xyz/<git-hash>/file`. An example URL format would be:
```
https://web-prover-circuits.pluto.xyz/4e342aa123f1ba339875d5efacb4c9b225b3f6ec/http_verification_1024b.bin
```

When a browser requests a file, it typically includes the header `Accept-Encoding: gzip`. In response, the server returns the gzipped content, which the browser automatically decompresses on the fly and presents to the developer as an uncompressed file.

Similarly, **a non-browser client should include the `Accept-Encoding: gzip`** header in its request to download the gzipped file. If this header is not included, Google Cloud Storage will serve the decompressed version of the file.

To illustrate this behavior more clearly, consider the following examples:

```
# Download the gzipped file
curl -v "https://web-prover-circuits.pluto.xyz/<githash>/http_verification_1024b.bin" -H "Accept-Encoding: gzip" > http_verification_1024b.bin.gz

# Download the decompressed file
curl -v "https://web-prover-circuits.pluto.xyz/<githash>/http_verification_1024b.bin" > http_verification_1024b.bin
```


Closes #92 