### PR TITLE
Colin: feat/arbitrary sized circuits

### DIFF
--- a/circuits/chacha20/authentication.circom
+++ b/circuits/chacha20/authentication.circom
@@ -156,7 +156,7 @@ template PlaintextAuthentication(DATA_BYTES, PUBLIC_IO_LENGTH) {
   signal plaintext_digest   <== PolynomialDigestWithCounter(DATA_BYTES)(zeroed_plaintext, ciphertext_digest, step_in[1]);
 
   step_out[0] <== step_in[0] - part_ciphertext_digest + plaintext_digest;
-  step_in[1] <== plaintext_length;
+  step_out[1] <== plaintext_length;
   for (var i = 2 ; i < PUBLIC_IO_LENGTH ; i++) {
     step_out[i] <== step_in[i];
   }

--- a/circuits/test/chacha20/authentication.test.ts
+++ b/circuits/test/chacha20/authentication.test.ts
@@ -5,129 +5,129 @@ import { assert } from "chai";
 
 describe("Plaintext Authentication", () => {
     let circuit: WitnessTester<["key", "nonce", "counter", "plaintext", "ciphertext_digest", "step_in"], ["step_out"]>;
-    // describe("16 block test", () => {
-    //     it("should perform encryption", async () => {
-    //         circuit = await circomkit.WitnessTester(`PlaintextAuthentication`, {
-    //             file: "chacha20/authentication",
-    //             template: "PlaintextAuthentication",
-    //             params: [64, PUBLIC_IO_VARIABLES] // number of bytes for plaintext
-    //         });
-    //         // Test case from RCF https://www.rfc-editor.org/rfc/rfc7539.html#section-2.4.2
-    //         // the input encoding here is not the most intuitive. inputs are serialized as little endian.
-    //         // i.e. "e4e7f110" is serialized as "10 f1 e7 e4". So the way i am reading in inputs is
-    //         // to ensure that every 32 bit word is byte reversed before being turned into bits.
-    //         // i think this should be easy when we compute witness in rust.
-    //         let keyBytes = [
-    //             0x00, 0x01, 0x02, 0x03,
-    //             0x04, 0x05, 0x06, 0x07,
-    //             0x08, 0x09, 0x0a, 0x0b,
-    //             0x0c, 0x0d, 0x0e, 0x0f,
-    //             0x10, 0x11, 0x12, 0x13,
-    //             0x14, 0x15, 0x16, 0x17,
-    //             0x18, 0x19, 0x1a, 0x1b,
-    //             0x1c, 0x1d, 0x1e, 0x1f
-    //         ];
+    describe("16 block test", () => {
+        it("should perform encryption", async () => {
+            circuit = await circomkit.WitnessTester(`PlaintextAuthentication`, {
+                file: "chacha20/authentication",
+                template: "PlaintextAuthentication",
+                params: [64, PUBLIC_IO_VARIABLES] // number of bytes for plaintext
+            });
+            // Test case from RCF https://www.rfc-editor.org/rfc/rfc7539.html#section-2.4.2
+            // the input encoding here is not the most intuitive. inputs are serialized as little endian.
+            // i.e. "e4e7f110" is serialized as "10 f1 e7 e4". So the way i am reading in inputs is
+            // to ensure that every 32 bit word is byte reversed before being turned into bits.
+            // i think this should be easy when we compute witness in rust.
+            let keyBytes = [
+                0x00, 0x01, 0x02, 0x03,
+                0x04, 0x05, 0x06, 0x07,
+                0x08, 0x09, 0x0a, 0x0b,
+                0x0c, 0x0d, 0x0e, 0x0f,
+                0x10, 0x11, 0x12, 0x13,
+                0x14, 0x15, 0x16, 0x17,
+                0x18, 0x19, 0x1a, 0x1b,
+                0x1c, 0x1d, 0x1e, 0x1f
+            ];
 
-    //         let nonceBytes =
-    //             [
-    //                 0x00, 0x00, 0x00, 0x00,
-    //                 0x00, 0x00, 0x00, 0x4a,
-    //                 0x00, 0x00, 0x00, 0x00
-    //             ];
-    //         let plaintextBytes =
-    //             [
-    //                 0x4c, 0x61, 0x64, 0x69, 0x65, 0x73, 0x20, 0x61, 0x6e, 0x64, 0x20, 0x47, 0x65, 0x6e, 0x74, 0x6c,
-    //                 0x65, 0x6d, 0x65, 0x6e, 0x20, 0x6f, 0x66, 0x20, 0x74, 0x68, 0x65, 0x20, 0x63, 0x6c, 0x61, 0x73,
-    //                 0x73, 0x20, 0x6f, 0x66, 0x20, 0x27, 0x39, 0x39, 0x3a, 0x20, 0x49, 0x66, 0x20, 0x49, 0x20, 0x63,
-    //                 0x6f, 0x75, 0x6c, 0x64, 0x20, 0x6f, 0x66, 0x66, 0x65, 0x72, 0x20, 0x79, 0x6f, 0x75, 0x20, 0x6f,
-    //             ];
-    //         let ciphertextBytes =
-    //             [
-    //                 0x6e, 0x2e, 0x35, 0x9a, 0x25, 0x68, 0xf9, 0x80, 0x41, 0xba, 0x07, 0x28, 0xdd, 0x0d, 0x69, 0x81,
-    //                 0xe9, 0x7e, 0x7a, 0xec, 0x1d, 0x43, 0x60, 0xc2, 0x0a, 0x27, 0xaf, 0xcc, 0xfd, 0x9f, 0xae, 0x0b,
-    //                 0xf9, 0x1b, 0x65, 0xc5, 0x52, 0x47, 0x33, 0xab, 0x8f, 0x59, 0x3d, 0xab, 0xcd, 0x62, 0xb3, 0x57,
-    //                 0x16, 0x39, 0xd6, 0x24, 0xe6, 0x51, 0x52, 0xab, 0x8f, 0x53, 0x0c, 0x35, 0x9f, 0x08, 0x61, 0xd8
-    //             ];
-    //         const counterBits = uintArray32ToBits([1])[0];
-    //         let ciphertext_digest = DataHasher(ciphertextBytes);
-    //         let step_in = Array(PUBLIC_IO_VARIABLES).fill(0);
-    //         let w = await circuit.compute({
-    //             key: toInput(Buffer.from(keyBytes)),
-    //             nonce: toInput(Buffer.from(nonceBytes)),
-    //             counter: counterBits,
-    //             plaintext: plaintextBytes,
-    //             ciphertext_digest: ciphertext_digest,
-    //             step_in,
-    //         }, (["step_out"]));
+            let nonceBytes =
+                [
+                    0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x4a,
+                    0x00, 0x00, 0x00, 0x00
+                ];
+            let plaintextBytes =
+                [
+                    0x4c, 0x61, 0x64, 0x69, 0x65, 0x73, 0x20, 0x61, 0x6e, 0x64, 0x20, 0x47, 0x65, 0x6e, 0x74, 0x6c,
+                    0x65, 0x6d, 0x65, 0x6e, 0x20, 0x6f, 0x66, 0x20, 0x74, 0x68, 0x65, 0x20, 0x63, 0x6c, 0x61, 0x73,
+                    0x73, 0x20, 0x6f, 0x66, 0x20, 0x27, 0x39, 0x39, 0x3a, 0x20, 0x49, 0x66, 0x20, 0x49, 0x20, 0x63,
+                    0x6f, 0x75, 0x6c, 0x64, 0x20, 0x6f, 0x66, 0x66, 0x65, 0x72, 0x20, 0x79, 0x6f, 0x75, 0x20, 0x6f,
+                ];
+            let ciphertextBytes =
+                [
+                    0x6e, 0x2e, 0x35, 0x9a, 0x25, 0x68, 0xf9, 0x80, 0x41, 0xba, 0x07, 0x28, 0xdd, 0x0d, 0x69, 0x81,
+                    0xe9, 0x7e, 0x7a, 0xec, 0x1d, 0x43, 0x60, 0xc2, 0x0a, 0x27, 0xaf, 0xcc, 0xfd, 0x9f, 0xae, 0x0b,
+                    0xf9, 0x1b, 0x65, 0xc5, 0x52, 0x47, 0x33, 0xab, 0x8f, 0x59, 0x3d, 0xab, 0xcd, 0x62, 0xb3, 0x57,
+                    0x16, 0x39, 0xd6, 0x24, 0xe6, 0x51, 0x52, 0xab, 0x8f, 0x53, 0x0c, 0x35, 0x9f, 0x08, 0x61, 0xd8
+                ];
+            const counterBits = uintArray32ToBits([1])[0];
+            let ciphertext_digest = DataHasher(ciphertextBytes);
+            let step_in = Array(PUBLIC_IO_VARIABLES).fill(0);
+            let w = await circuit.compute({
+                key: toInput(Buffer.from(keyBytes)),
+                nonce: toInput(Buffer.from(nonceBytes)),
+                counter: counterBits,
+                plaintext: plaintextBytes,
+                ciphertext_digest: ciphertext_digest,
+                step_in,
+            }, (["step_out"]));
 
-    //         // Output
-    //         let plaintext_digest = PolynomialDigest(plaintextBytes, ciphertext_digest, BigInt(0));
-    //         let output = modAdd(plaintext_digest - ciphertext_digest, BigInt(0));
-    //         const stepOutArray = w.step_out as unknown as BigInt[];
-    //         assert.deepEqual(stepOutArray[0], output);
-    //     });
-    // });
+            // Output
+            let plaintext_digest = PolynomialDigest(plaintextBytes, ciphertext_digest, BigInt(0));
+            let output = modAdd(plaintext_digest - ciphertext_digest, BigInt(0));
+            const stepOutArray = w.step_out as unknown as BigInt[];
+            assert.deepEqual(stepOutArray[0], output);
+        });
+    });
 
-    // describe("padded plaintext", () => {
-    //     it("should perform encryption", async () => {
-    //         circuit = await circomkit.WitnessTester(`PlaintextAuthentication`, {
-    //             file: "chacha20/authentication",
-    //             template: "PlaintextAuthentication",
-    //             params: [128, PUBLIC_IO_VARIABLES] // number of bytes in plaintext
-    //         });
-    //         // Test case from RCF https://www.rfc-editor.org/rfc/rfc7539.html#section-2.4.2
-    //         // the input encoding here is not the most intuitive. inputs are serialized as little endian.
-    //         // i.e. "e4e7f110" is serialized as "10 f1 e7 e4". So the way i am reading in inputs is
-    //         // to ensure that every 32 bit word is byte reversed before being turned into bits.
-    //         // i think this should be easy when we compute witness in rust.
-    //         let keyBytes = [
-    //             0x00, 0x01, 0x02, 0x03,
-    //             0x04, 0x05, 0x06, 0x07,
-    //             0x08, 0x09, 0x0a, 0x0b,
-    //             0x0c, 0x0d, 0x0e, 0x0f,
-    //             0x10, 0x11, 0x12, 0x13,
-    //             0x14, 0x15, 0x16, 0x17,
-    //             0x18, 0x19, 0x1a, 0x1b,
-    //             0x1c, 0x1d, 0x1e, 0x1f
-    //         ];
+    describe("padded plaintext", () => {
+        it("should perform encryption", async () => {
+            circuit = await circomkit.WitnessTester(`PlaintextAuthentication`, {
+                file: "chacha20/authentication",
+                template: "PlaintextAuthentication",
+                params: [128, PUBLIC_IO_VARIABLES] // number of bytes in plaintext
+            });
+            // Test case from RCF https://www.rfc-editor.org/rfc/rfc7539.html#section-2.4.2
+            // the input encoding here is not the most intuitive. inputs are serialized as little endian.
+            // i.e. "e4e7f110" is serialized as "10 f1 e7 e4". So the way i am reading in inputs is
+            // to ensure that every 32 bit word is byte reversed before being turned into bits.
+            // i think this should be easy when we compute witness in rust.
+            let keyBytes = [
+                0x00, 0x01, 0x02, 0x03,
+                0x04, 0x05, 0x06, 0x07,
+                0x08, 0x09, 0x0a, 0x0b,
+                0x0c, 0x0d, 0x0e, 0x0f,
+                0x10, 0x11, 0x12, 0x13,
+                0x14, 0x15, 0x16, 0x17,
+                0x18, 0x19, 0x1a, 0x1b,
+                0x1c, 0x1d, 0x1e, 0x1f
+            ];
 
-    //         let nonceBytes =
-    //             [
-    //                 0x00, 0x00, 0x00, 0x00,
-    //                 0x00, 0x00, 0x00, 0x4a,
-    //                 0x00, 0x00, 0x00, 0x00
-    //             ];
-    //         let plaintextBytes =
-    //             toByte("Ladies and Gentlemen of the class of '99: If I could offer you only one tip ");
+            let nonceBytes =
+                [
+                    0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x4a,
+                    0x00, 0x00, 0x00, 0x00
+                ];
+            let plaintextBytes =
+                toByte("Ladies and Gentlemen of the class of '99: If I could offer you only one tip ");
 
-    //         let ciphertextBytes =
-    //             [
-    //                 0x6e, 0x2e, 0x35, 0x9a, 0x25, 0x68, 0xf9, 0x80, 0x41, 0xba, 0x07, 0x28, 0xdd, 0x0d, 0x69, 0x81,
-    //                 0xe9, 0x7e, 0x7a, 0xec, 0x1d, 0x43, 0x60, 0xc2, 0x0a, 0x27, 0xaf, 0xcc, 0xfd, 0x9f, 0xae, 0x0b,
-    //                 0xf9, 0x1b, 0x65, 0xc5, 0x52, 0x47, 0x33, 0xab, 0x8f, 0x59, 0x3d, 0xab, 0xcd, 0x62, 0xb3, 0x57,
-    //                 0x16, 0x39, 0xd6, 0x24, 0xe6, 0x51, 0x52, 0xab, 0x8f, 0x53, 0x0c, 0x35, 0x9f, 0x08, 0x61, 0xd8,
-    //                 0x07, 0xca, 0x0d, 0xbf, 0x50, 0x0d, 0x6a, 0x61, 0x56, 0xa3, 0x8e, 0x08
-    //             ];
-    //         let totalLength = 128;
-    //         let paddedPlaintextBytes = plaintextBytes.concat(Array(totalLength - plaintextBytes.length).fill(-1));
-    //         const counterBits = uintArray32ToBits([1])[0];
-    //         let ciphertext_digest = DataHasher(ciphertextBytes);
-    //         let step_in = Array(PUBLIC_IO_VARIABLES).fill(0);
-    //         let w = await circuit.compute({
-    //             key: toInput(Buffer.from(keyBytes)),
-    //             nonce: toInput(Buffer.from(nonceBytes)),
-    //             counter: counterBits,
-    //             plaintext: paddedPlaintextBytes,
-    //             step_in,
-    //             ciphertext_digest: ciphertext_digest,
-    //         }, (["step_out"]));
+            let ciphertextBytes =
+                [
+                    0x6e, 0x2e, 0x35, 0x9a, 0x25, 0x68, 0xf9, 0x80, 0x41, 0xba, 0x07, 0x28, 0xdd, 0x0d, 0x69, 0x81,
+                    0xe9, 0x7e, 0x7a, 0xec, 0x1d, 0x43, 0x60, 0xc2, 0x0a, 0x27, 0xaf, 0xcc, 0xfd, 0x9f, 0xae, 0x0b,
+                    0xf9, 0x1b, 0x65, 0xc5, 0x52, 0x47, 0x33, 0xab, 0x8f, 0x59, 0x3d, 0xab, 0xcd, 0x62, 0xb3, 0x57,
+                    0x16, 0x39, 0xd6, 0x24, 0xe6, 0x51, 0x52, 0xab, 0x8f, 0x53, 0x0c, 0x35, 0x9f, 0x08, 0x61, 0xd8,
+                    0x07, 0xca, 0x0d, 0xbf, 0x50, 0x0d, 0x6a, 0x61, 0x56, 0xa3, 0x8e, 0x08
+                ];
+            let totalLength = 128;
+            let paddedPlaintextBytes = plaintextBytes.concat(Array(totalLength - plaintextBytes.length).fill(-1));
+            const counterBits = uintArray32ToBits([1])[0];
+            let ciphertext_digest = DataHasher(ciphertextBytes);
+            let step_in = Array(PUBLIC_IO_VARIABLES).fill(0);
+            let w = await circuit.compute({
+                key: toInput(Buffer.from(keyBytes)),
+                nonce: toInput(Buffer.from(nonceBytes)),
+                counter: counterBits,
+                plaintext: paddedPlaintextBytes,
+                step_in,
+                ciphertext_digest: ciphertext_digest,
+            }, (["step_out"]));
 
-    //         let plaintext_digest = PolynomialDigest(plaintextBytes, ciphertext_digest, BigInt(0));
-    //         let output = modAdd(plaintext_digest - ciphertext_digest, BigInt(0));
-    //         const stepOutArray = w.step_out as unknown as BigInt[];
-    //         assert.deepEqual(stepOutArray[0], output);
-    //     });
-    // });
+            let plaintext_digest = PolynomialDigest(plaintextBytes, ciphertext_digest, BigInt(0));
+            let output = modAdd(plaintext_digest - ciphertext_digest, BigInt(0));
+            const stepOutArray = w.step_out as unknown as BigInt[];
+            assert.deepEqual(stepOutArray[0], output);
+        });
+    });
 
     describe("padded plaintext: split", () => {
         it("should perform encryption", async () => {

--- a/circuits/test/chacha20/authentication.test.ts
+++ b/circuits/test/chacha20/authentication.test.ts
@@ -5,75 +5,136 @@ import { assert } from "chai";
 
 describe("Plaintext Authentication", () => {
     let circuit: WitnessTester<["key", "nonce", "counter", "plaintext", "ciphertext_digest", "step_in"], ["step_out"]>;
-    describe("16 block test", () => {
+    // describe("16 block test", () => {
+    //     it("should perform encryption", async () => {
+    //         circuit = await circomkit.WitnessTester(`PlaintextAuthentication`, {
+    //             file: "chacha20/authentication",
+    //             template: "PlaintextAuthentication",
+    //             params: [64, PUBLIC_IO_VARIABLES] // number of bytes for plaintext
+    //         });
+    //         // Test case from RCF https://www.rfc-editor.org/rfc/rfc7539.html#section-2.4.2
+    //         // the input encoding here is not the most intuitive. inputs are serialized as little endian.
+    //         // i.e. "e4e7f110" is serialized as "10 f1 e7 e4". So the way i am reading in inputs is
+    //         // to ensure that every 32 bit word is byte reversed before being turned into bits.
+    //         // i think this should be easy when we compute witness in rust.
+    //         let keyBytes = [
+    //             0x00, 0x01, 0x02, 0x03,
+    //             0x04, 0x05, 0x06, 0x07,
+    //             0x08, 0x09, 0x0a, 0x0b,
+    //             0x0c, 0x0d, 0x0e, 0x0f,
+    //             0x10, 0x11, 0x12, 0x13,
+    //             0x14, 0x15, 0x16, 0x17,
+    //             0x18, 0x19, 0x1a, 0x1b,
+    //             0x1c, 0x1d, 0x1e, 0x1f
+    //         ];
+
+    //         let nonceBytes =
+    //             [
+    //                 0x00, 0x00, 0x00, 0x00,
+    //                 0x00, 0x00, 0x00, 0x4a,
+    //                 0x00, 0x00, 0x00, 0x00
+    //             ];
+    //         let plaintextBytes =
+    //             [
+    //                 0x4c, 0x61, 0x64, 0x69, 0x65, 0x73, 0x20, 0x61, 0x6e, 0x64, 0x20, 0x47, 0x65, 0x6e, 0x74, 0x6c,
+    //                 0x65, 0x6d, 0x65, 0x6e, 0x20, 0x6f, 0x66, 0x20, 0x74, 0x68, 0x65, 0x20, 0x63, 0x6c, 0x61, 0x73,
+    //                 0x73, 0x20, 0x6f, 0x66, 0x20, 0x27, 0x39, 0x39, 0x3a, 0x20, 0x49, 0x66, 0x20, 0x49, 0x20, 0x63,
+    //                 0x6f, 0x75, 0x6c, 0x64, 0x20, 0x6f, 0x66, 0x66, 0x65, 0x72, 0x20, 0x79, 0x6f, 0x75, 0x20, 0x6f,
+    //             ];
+    //         let ciphertextBytes =
+    //             [
+    //                 0x6e, 0x2e, 0x35, 0x9a, 0x25, 0x68, 0xf9, 0x80, 0x41, 0xba, 0x07, 0x28, 0xdd, 0x0d, 0x69, 0x81,
+    //                 0xe9, 0x7e, 0x7a, 0xec, 0x1d, 0x43, 0x60, 0xc2, 0x0a, 0x27, 0xaf, 0xcc, 0xfd, 0x9f, 0xae, 0x0b,
+    //                 0xf9, 0x1b, 0x65, 0xc5, 0x52, 0x47, 0x33, 0xab, 0x8f, 0x59, 0x3d, 0xab, 0xcd, 0x62, 0xb3, 0x57,
+    //                 0x16, 0x39, 0xd6, 0x24, 0xe6, 0x51, 0x52, 0xab, 0x8f, 0x53, 0x0c, 0x35, 0x9f, 0x08, 0x61, 0xd8
+    //             ];
+    //         const counterBits = uintArray32ToBits([1])[0];
+    //         let ciphertext_digest = DataHasher(ciphertextBytes);
+    //         let step_in = Array(PUBLIC_IO_VARIABLES).fill(0);
+    //         let w = await circuit.compute({
+    //             key: toInput(Buffer.from(keyBytes)),
+    //             nonce: toInput(Buffer.from(nonceBytes)),
+    //             counter: counterBits,
+    //             plaintext: plaintextBytes,
+    //             ciphertext_digest: ciphertext_digest,
+    //             step_in,
+    //         }, (["step_out"]));
+
+    //         // Output
+    //         let plaintext_digest = PolynomialDigest(plaintextBytes, ciphertext_digest, BigInt(0));
+    //         let output = modAdd(plaintext_digest - ciphertext_digest, BigInt(0));
+    //         const stepOutArray = w.step_out as unknown as BigInt[];
+    //         assert.deepEqual(stepOutArray[0], output);
+    //     });
+    // });
+
+    // describe("padded plaintext", () => {
+    //     it("should perform encryption", async () => {
+    //         circuit = await circomkit.WitnessTester(`PlaintextAuthentication`, {
+    //             file: "chacha20/authentication",
+    //             template: "PlaintextAuthentication",
+    //             params: [128, PUBLIC_IO_VARIABLES] // number of bytes in plaintext
+    //         });
+    //         // Test case from RCF https://www.rfc-editor.org/rfc/rfc7539.html#section-2.4.2
+    //         // the input encoding here is not the most intuitive. inputs are serialized as little endian.
+    //         // i.e. "e4e7f110" is serialized as "10 f1 e7 e4". So the way i am reading in inputs is
+    //         // to ensure that every 32 bit word is byte reversed before being turned into bits.
+    //         // i think this should be easy when we compute witness in rust.
+    //         let keyBytes = [
+    //             0x00, 0x01, 0x02, 0x03,
+    //             0x04, 0x05, 0x06, 0x07,
+    //             0x08, 0x09, 0x0a, 0x0b,
+    //             0x0c, 0x0d, 0x0e, 0x0f,
+    //             0x10, 0x11, 0x12, 0x13,
+    //             0x14, 0x15, 0x16, 0x17,
+    //             0x18, 0x19, 0x1a, 0x1b,
+    //             0x1c, 0x1d, 0x1e, 0x1f
+    //         ];
+
+    //         let nonceBytes =
+    //             [
+    //                 0x00, 0x00, 0x00, 0x00,
+    //                 0x00, 0x00, 0x00, 0x4a,
+    //                 0x00, 0x00, 0x00, 0x00
+    //             ];
+    //         let plaintextBytes =
+    //             toByte("Ladies and Gentlemen of the class of '99: If I could offer you only one tip ");
+
+    //         let ciphertextBytes =
+    //             [
+    //                 0x6e, 0x2e, 0x35, 0x9a, 0x25, 0x68, 0xf9, 0x80, 0x41, 0xba, 0x07, 0x28, 0xdd, 0x0d, 0x69, 0x81,
+    //                 0xe9, 0x7e, 0x7a, 0xec, 0x1d, 0x43, 0x60, 0xc2, 0x0a, 0x27, 0xaf, 0xcc, 0xfd, 0x9f, 0xae, 0x0b,
+    //                 0xf9, 0x1b, 0x65, 0xc5, 0x52, 0x47, 0x33, 0xab, 0x8f, 0x59, 0x3d, 0xab, 0xcd, 0x62, 0xb3, 0x57,
+    //                 0x16, 0x39, 0xd6, 0x24, 0xe6, 0x51, 0x52, 0xab, 0x8f, 0x53, 0x0c, 0x35, 0x9f, 0x08, 0x61, 0xd8,
+    //                 0x07, 0xca, 0x0d, 0xbf, 0x50, 0x0d, 0x6a, 0x61, 0x56, 0xa3, 0x8e, 0x08
+    //             ];
+    //         let totalLength = 128;
+    //         let paddedPlaintextBytes = plaintextBytes.concat(Array(totalLength - plaintextBytes.length).fill(-1));
+    //         const counterBits = uintArray32ToBits([1])[0];
+    //         let ciphertext_digest = DataHasher(ciphertextBytes);
+    //         let step_in = Array(PUBLIC_IO_VARIABLES).fill(0);
+    //         let w = await circuit.compute({
+    //             key: toInput(Buffer.from(keyBytes)),
+    //             nonce: toInput(Buffer.from(nonceBytes)),
+    //             counter: counterBits,
+    //             plaintext: paddedPlaintextBytes,
+    //             step_in,
+    //             ciphertext_digest: ciphertext_digest,
+    //         }, (["step_out"]));
+
+    //         let plaintext_digest = PolynomialDigest(plaintextBytes, ciphertext_digest, BigInt(0));
+    //         let output = modAdd(plaintext_digest - ciphertext_digest, BigInt(0));
+    //         const stepOutArray = w.step_out as unknown as BigInt[];
+    //         assert.deepEqual(stepOutArray[0], output);
+    //     });
+    // });
+
+    describe("padded plaintext: split", () => {
         it("should perform encryption", async () => {
             circuit = await circomkit.WitnessTester(`PlaintextAuthentication`, {
                 file: "chacha20/authentication",
                 template: "PlaintextAuthentication",
-                params: [64, PUBLIC_IO_VARIABLES] // number of bytes for plaintext
-            });
-            // Test case from RCF https://www.rfc-editor.org/rfc/rfc7539.html#section-2.4.2
-            // the input encoding here is not the most intuitive. inputs are serialized as little endian.
-            // i.e. "e4e7f110" is serialized as "10 f1 e7 e4". So the way i am reading in inputs is
-            // to ensure that every 32 bit word is byte reversed before being turned into bits.
-            // i think this should be easy when we compute witness in rust.
-            let keyBytes = [
-                0x00, 0x01, 0x02, 0x03,
-                0x04, 0x05, 0x06, 0x07,
-                0x08, 0x09, 0x0a, 0x0b,
-                0x0c, 0x0d, 0x0e, 0x0f,
-                0x10, 0x11, 0x12, 0x13,
-                0x14, 0x15, 0x16, 0x17,
-                0x18, 0x19, 0x1a, 0x1b,
-                0x1c, 0x1d, 0x1e, 0x1f
-            ];
-
-            let nonceBytes =
-                [
-                    0x00, 0x00, 0x00, 0x00,
-                    0x00, 0x00, 0x00, 0x4a,
-                    0x00, 0x00, 0x00, 0x00
-                ];
-            let plaintextBytes =
-                [
-                    0x4c, 0x61, 0x64, 0x69, 0x65, 0x73, 0x20, 0x61, 0x6e, 0x64, 0x20, 0x47, 0x65, 0x6e, 0x74, 0x6c,
-                    0x65, 0x6d, 0x65, 0x6e, 0x20, 0x6f, 0x66, 0x20, 0x74, 0x68, 0x65, 0x20, 0x63, 0x6c, 0x61, 0x73,
-                    0x73, 0x20, 0x6f, 0x66, 0x20, 0x27, 0x39, 0x39, 0x3a, 0x20, 0x49, 0x66, 0x20, 0x49, 0x20, 0x63,
-                    0x6f, 0x75, 0x6c, 0x64, 0x20, 0x6f, 0x66, 0x66, 0x65, 0x72, 0x20, 0x79, 0x6f, 0x75, 0x20, 0x6f,
-                ];
-            let ciphertextBytes =
-                [
-                    0x6e, 0x2e, 0x35, 0x9a, 0x25, 0x68, 0xf9, 0x80, 0x41, 0xba, 0x07, 0x28, 0xdd, 0x0d, 0x69, 0x81,
-                    0xe9, 0x7e, 0x7a, 0xec, 0x1d, 0x43, 0x60, 0xc2, 0x0a, 0x27, 0xaf, 0xcc, 0xfd, 0x9f, 0xae, 0x0b,
-                    0xf9, 0x1b, 0x65, 0xc5, 0x52, 0x47, 0x33, 0xab, 0x8f, 0x59, 0x3d, 0xab, 0xcd, 0x62, 0xb3, 0x57,
-                    0x16, 0x39, 0xd6, 0x24, 0xe6, 0x51, 0x52, 0xab, 0x8f, 0x53, 0x0c, 0x35, 0x9f, 0x08, 0x61, 0xd8
-                ];
-            const counterBits = uintArray32ToBits([1])[0];
-            let ciphertext_digest = DataHasher(ciphertextBytes);
-            let step_in = Array(PUBLIC_IO_VARIABLES).fill(0);
-            let w = await circuit.compute({
-                key: toInput(Buffer.from(keyBytes)),
-                nonce: toInput(Buffer.from(nonceBytes)),
-                counter: counterBits,
-                plaintext: plaintextBytes,
-                ciphertext_digest: ciphertext_digest,
-                step_in,
-            }, (["step_out"]));
-
-            // Output
-            let plaintext_digest = PolynomialDigest(plaintextBytes, ciphertext_digest, BigInt(0));
-            let output = modAdd(plaintext_digest - ciphertext_digest, BigInt(0));
-            const stepOutArray = w.step_out as unknown as BigInt[];
-            assert.deepEqual(stepOutArray[0], output);
-        });
-    });
-
-    describe("padded plaintext", () => {
-        it("should perform encryption", async () => {
-            circuit = await circomkit.WitnessTester(`PlaintextAuthentication`, {
-                file: "chacha20/authentication",
-                template: "PlaintextAuthentication",
-                params: [128, PUBLIC_IO_VARIABLES] // number of bytes in plaintext
+                params: [64, PUBLIC_IO_VARIABLES] // number of bytes in plaintext
             });
             // Test case from RCF https://www.rfc-editor.org/rfc/rfc7539.html#section-2.4.2
             // the input encoding here is not the most intuitive. inputs are serialized as little endian.
@@ -110,21 +171,32 @@ describe("Plaintext Authentication", () => {
                 ];
             let totalLength = 128;
             let paddedPlaintextBytes = plaintextBytes.concat(Array(totalLength - plaintextBytes.length).fill(-1));
-            const counterBits = uintArray32ToBits([1])[0];
+            const counterBits0 = uintArray32ToBits([1])[0];
             let ciphertext_digest = DataHasher(ciphertextBytes);
+            console.log("ciphertext_digest: ", ciphertext_digest);
             let step_in = Array(PUBLIC_IO_VARIABLES).fill(0);
-            let w = await circuit.compute({
+            let w_0 = await circuit.compute({
                 key: toInput(Buffer.from(keyBytes)),
                 nonce: toInput(Buffer.from(nonceBytes)),
-                counter: counterBits,
-                plaintext: paddedPlaintextBytes,
+                counter: counterBits0,
+                plaintext: paddedPlaintextBytes.slice(0, 64),
                 step_in,
+                ciphertext_digest: ciphertext_digest,
+            }, (["step_out"]));
+
+            const counterBits1 = uintArray32ToBits([2])[0];
+            let w_1 = await circuit.compute({
+                key: toInput(Buffer.from(keyBytes)),
+                nonce: toInput(Buffer.from(nonceBytes)),
+                counter: counterBits1,
+                plaintext: paddedPlaintextBytes.slice(64),
+                step_in: w_0.step_out,
                 ciphertext_digest: ciphertext_digest,
             }, (["step_out"]));
 
             let plaintext_digest = PolynomialDigest(plaintextBytes, ciphertext_digest, BigInt(0));
             let output = modAdd(plaintext_digest - ciphertext_digest, BigInt(0));
-            const stepOutArray = w.step_out as unknown as BigInt[];
+            const stepOutArray = w_1.step_out as unknown as BigInt[];
             assert.deepEqual(stepOutArray[0], output);
         });
     });

--- a/circuits/test/chacha20/authentication.test.ts
+++ b/circuits/test/chacha20/authentication.test.ts
@@ -1,16 +1,16 @@
 import { WitnessTester } from "circomkit";
-import { circomkit, PolynomialDigest, toByte, toUint32Array, uintArray32ToBits, modAdd } from "../common";
+import { circomkit, PolynomialDigest, toByte, toUint32Array, uintArray32ToBits, modAdd, PUBLIC_IO_VARIABLES } from "../common";
 import { DataHasher } from "../common/poseidon";
 import { assert } from "chai";
 
 describe("Plaintext Authentication", () => {
-    let circuit: WitnessTester<["key", "nonce", "counter", "plaintext", "plaintext_index_counter", "ciphertext_digest", "step_in"], ["step_out"]>;
+    let circuit: WitnessTester<["key", "nonce", "counter", "plaintext", "ciphertext_digest", "step_in"], ["step_out"]>;
     describe("16 block test", () => {
         it("should perform encryption", async () => {
             circuit = await circomkit.WitnessTester(`PlaintextAuthentication`, {
                 file: "chacha20/authentication",
                 template: "PlaintextAuthentication",
-                params: [64] // number of bytes for plaintext
+                params: [64, PUBLIC_IO_VARIABLES] // number of bytes for plaintext
             });
             // Test case from RCF https://www.rfc-editor.org/rfc/rfc7539.html#section-2.4.2
             // the input encoding here is not the most intuitive. inputs are serialized as little endian.
@@ -50,20 +50,21 @@ describe("Plaintext Authentication", () => {
                 ];
             const counterBits = uintArray32ToBits([1])[0];
             let ciphertext_digest = DataHasher(ciphertextBytes);
+            let step_in = Array(PUBLIC_IO_VARIABLES).fill(0);
             let w = await circuit.compute({
                 key: toInput(Buffer.from(keyBytes)),
                 nonce: toInput(Buffer.from(nonceBytes)),
                 counter: counterBits,
                 plaintext: plaintextBytes,
-                plaintext_index_counter: 0,
                 ciphertext_digest: ciphertext_digest,
-                step_in: 0
+                step_in,
             }, (["step_out"]));
 
             // Output
             let plaintext_digest = PolynomialDigest(plaintextBytes, ciphertext_digest, BigInt(0));
             let output = modAdd(plaintext_digest - ciphertext_digest, BigInt(0));
-            assert.deepEqual(w.step_out, output);
+            const stepOutArray = w.step_out as unknown as BigInt[];
+            assert.deepEqual(stepOutArray[0], output);
         });
     });
 
@@ -72,7 +73,7 @@ describe("Plaintext Authentication", () => {
             circuit = await circomkit.WitnessTester(`PlaintextAuthentication`, {
                 file: "chacha20/authentication",
                 template: "PlaintextAuthentication",
-                params: [128] // number of bytes in plaintext
+                params: [128, PUBLIC_IO_VARIABLES] // number of bytes in plaintext
             });
             // Test case from RCF https://www.rfc-editor.org/rfc/rfc7539.html#section-2.4.2
             // the input encoding here is not the most intuitive. inputs are serialized as little endian.
@@ -111,19 +112,20 @@ describe("Plaintext Authentication", () => {
             let paddedPlaintextBytes = plaintextBytes.concat(Array(totalLength - plaintextBytes.length).fill(-1));
             const counterBits = uintArray32ToBits([1])[0];
             let ciphertext_digest = DataHasher(ciphertextBytes);
+            let step_in = Array(PUBLIC_IO_VARIABLES).fill(0);
             let w = await circuit.compute({
                 key: toInput(Buffer.from(keyBytes)),
                 nonce: toInput(Buffer.from(nonceBytes)),
                 counter: counterBits,
                 plaintext: paddedPlaintextBytes,
-                step_in: 0,
-                plaintext_index_counter: 0,
+                step_in,
                 ciphertext_digest: ciphertext_digest,
             }, (["step_out"]));
 
             let plaintext_digest = PolynomialDigest(plaintextBytes, ciphertext_digest, BigInt(0));
             let output = modAdd(plaintext_digest - ciphertext_digest, BigInt(0));
-            assert.deepEqual(w.step_out, output);
+            const stepOutArray = w.step_out as unknown as BigInt[];
+            assert.deepEqual(stepOutArray[0], output);
         });
     });
 });

--- a/circuits/test/common/index.ts
+++ b/circuits/test/common/index.ts
@@ -254,6 +254,8 @@ export function PolynomialDigest(coeffs: number[], input: bigint, counter: bigin
     return result;
 }
 
+export const PUBLIC_IO_VARIABLES = 9;
+
 // HTTP/1.1 200 OK
 // content-type: application/json; charset=utf-8
 // content-encoding: gzip

--- a/circuits/test/common/index.ts
+++ b/circuits/test/common/index.ts
@@ -254,7 +254,7 @@ export function PolynomialDigest(coeffs: number[], input: bigint, counter: bigin
     return result;
 }
 
-export const PUBLIC_IO_VARIABLES = 9;
+export const PUBLIC_IO_VARIABLES = 10;
 
 // HTTP/1.1 200 OK
 // content-type: application/json; charset=utf-8

--- a/circuits/test/common/index.ts
+++ b/circuits/test/common/index.ts
@@ -254,7 +254,7 @@ export function PolynomialDigest(coeffs: number[], input: bigint, counter: bigin
     return result;
 }
 
-export const PUBLIC_IO_VARIABLES = 10;
+export const PUBLIC_IO_VARIABLES = 11;
 
 // HTTP/1.1 200 OK
 // content-type: application/json; charset=utf-8

--- a/circuits/test/http/verification.test.ts
+++ b/circuits/test/http/verification.test.ts
@@ -1,4 +1,4 @@
-import { circomkit, WitnessTester, PolynomialDigest, http_response_plaintext, http_start_line, http_header_0, http_header_1, http_body, modAdd } from "../common";
+import { circomkit, WitnessTester, PolynomialDigest, http_response_plaintext, http_start_line, http_header_0, http_header_1, http_body, modAdd, PUBLIC_IO_VARIABLES } from "../common";
 import { assert } from "chai";
 import { poseidon1 } from "poseidon-lite";
 
@@ -24,33 +24,46 @@ const DATA_BYTES = 320;
 const MAX_NUMBER_OF_HEADERS = 2;
 
 describe("HTTP Verification", async () => {
-    let HTTPVerification: WitnessTester<["step_in", "data", "main_digests", "ciphertext_digest"], ["step_out"]>;
+    let HTTPVerification: WitnessTester<["step_in", "data", "machine_state", "main_digests", "ciphertext_digest"], ["step_out"]>;
     before(async () => {
         HTTPVerification = await circomkit.WitnessTester("http_nivc", {
             file: "http/verification",
             template: "HTTPVerification",
-            params: [DATA_BYTES, MAX_NUMBER_OF_HEADERS]
+            params: [DATA_BYTES, MAX_NUMBER_OF_HEADERS, PUBLIC_IO_VARIABLES]
         });
     });
     const mock_ct_digest = poseidon1([69]);
 
-    it("witness: http_response_plaintext, no header", async () => {
-        // Get all the hashes we need
-        let data_digest = PolynomialDigest(http_response_plaintext, mock_ct_digest, BigInt(0));
+    // Used across tests
+    let machine_state = Array(6).fill(0);
+    machine_state[0] = 1; // Sets the parsing start to 1
+    let step_in = Array(PUBLIC_IO_VARIABLES).fill(0);
+    step_in[3] = 1; // This would be the PD of the machine state given 1 is in the x^0 coeff
 
-        // Compute the HTTP info digest
-        let start_line_digest = PolynomialDigest(http_start_line, mock_ct_digest, BigInt(0));
-        let start_line_digest_hashed = poseidon1([start_line_digest]);
-        let body_digest = PolynomialDigest(http_body, mock_ct_digest, BigInt(0));
-        let body_digest_hashed = poseidon1([body_digest]);
-        // Use `modAdd` to get back a number between 0 and PRIME
-        let output_difference = modAdd(body_digest_hashed - start_line_digest_hashed - data_digest, BigInt(0));
+    // Get all the hashes we need
+    let plaintext_digest = PolynomialDigest(http_response_plaintext, mock_ct_digest, BigInt(0));
+
+    // Compute the HTTP info digest
+    let start_line_digest = PolynomialDigest(http_start_line, mock_ct_digest, BigInt(0));
+    let start_line_digest_hashed = poseidon1([start_line_digest]);
+    let header_0_digest = PolynomialDigest(http_header_0, mock_ct_digest, BigInt(0));
+    let header_0_digest_hashed = poseidon1([header_0_digest]);
+    let header_1_digest = PolynomialDigest(http_header_1, mock_ct_digest, BigInt(0));
+    let header_1_digest_hashed = poseidon1([header_1_digest]);
+    let body_digest = PolynomialDigest(http_body, mock_ct_digest, BigInt(0));
+    let output_difference = modAdd(-plaintext_digest, BigInt(0)); // TODO: need to add body_digest
+
+    it("witness: http_response_plaintext, no header", async () => {
+        // For this specific test, we need these registers set
+        step_in[4] = start_line_digest_hashed;
+        step_in[5] = 1; // Total number of matches to expect (sl)
 
         // Run the HTTP circuit
         // POTENTIAL BUG: I didn't get this to work with `expectPass` as it didn't compute `step_out` that way???
         let http_nivc_compute = await HTTPVerification.compute({
-            step_in: 0,  // This doesn't really matter for this test
+            step_in,  // This doesn't really matter for this test
             data: http_response_plaintext,
+            machine_state,
             main_digests: [start_line_digest].concat(Array(2).fill(0)),
             ciphertext_digest: mock_ct_digest
         }, ["step_out"]);
@@ -59,24 +72,16 @@ describe("HTTP Verification", async () => {
     });
 
     it("witness: http_response_plaintext, one header", async () => {
-        // Get all the hashes we need
-        let data_digest = PolynomialDigest(http_response_plaintext, mock_ct_digest, BigInt(0));
-
-        // Compute the HTTP info digest
-        let start_line_digest = PolynomialDigest(http_start_line, mock_ct_digest, BigInt(0));
-        let start_line_digest_hashed = poseidon1([start_line_digest]);
-        let header_0_digest = PolynomialDigest(http_header_0, mock_ct_digest, BigInt(0));
-        let header_0_digest_hashed = poseidon1([header_0_digest]);
-        let body_digest = PolynomialDigest(http_body, mock_ct_digest, BigInt(0));
-        let body_digest_hashed = poseidon1([body_digest]);
-        // Use `modAdd` to get back a number between 0 and PRIME
-        let output_difference = modAdd(body_digest_hashed - start_line_digest_hashed - header_0_digest_hashed - data_digest, BigInt(0));
+        // For this specific test, we need these registers set
+        step_in[4] = start_line_digest_hashed + header_0_digest_hashed;
+        step_in[5] = 2; // Total number of matches to expect (sl, h0)
 
         // Run the HTTP circuit
         // POTENTIAL BUG: I didn't get this to work with `expectPass` as it didn't compute `step_out` that way???
         let http_nivc_compute = await HTTPVerification.compute({
-            step_in: 0,  // This doesn't really matter for this test
+            step_in,  // This doesn't really matter for this test
             data: http_response_plaintext,
+            machine_state,
             main_digests: [start_line_digest, header_0_digest].concat(Array(1).fill(0)),
             ciphertext_digest: mock_ct_digest
         }, ["step_out"]);
@@ -85,26 +90,16 @@ describe("HTTP Verification", async () => {
     });
 
     it("witness: http_response_plaintext, two headers", async () => {
-        // Get all the hashes we need
-        let data_digest = PolynomialDigest(http_response_plaintext, mock_ct_digest, BigInt(0));
-
-        // Compute the HTTP info digest
-        let start_line_digest = PolynomialDigest(http_start_line, mock_ct_digest, BigInt(0));
-        let start_line_digest_hashed = poseidon1([start_line_digest]);
-        let header_0_digest = PolynomialDigest(http_header_0, mock_ct_digest, BigInt(0));
-        let header_0_digest_hashed = poseidon1([header_0_digest]);
-        let header_1_digest = PolynomialDigest(http_header_1, mock_ct_digest, BigInt(0));
-        let header_1_digest_hashed = poseidon1([header_1_digest]);
-        let body_digest = PolynomialDigest(http_body, mock_ct_digest, BigInt(0));
-        let body_digest_hashed = poseidon1([body_digest]);
-        // Use `modAdd` to get back a number between 0 and PRIME
-        let output_difference = modAdd(body_digest_hashed - start_line_digest_hashed - header_0_digest_hashed - header_1_digest_hashed - data_digest, BigInt(0));
+        // For this specific test, we need these registers set
+        step_in[4] = start_line_digest_hashed + header_0_digest_hashed + header_1_digest_hashed;
+        step_in[5] = 3; // Total number of matches to expect (sl, h0, h1)
 
         // Run the HTTP circuit
         // POTENTIAL BUG: I didn't get this to work with `expectPass` as it didn't compute `step_out` that way???
         let http_nivc_compute = await HTTPVerification.compute({
-            step_in: 0,  // This doesn't really matter for this test
+            step_in,  // This doesn't really matter for this test
             data: http_response_plaintext,
+            machine_state,
             main_digests: [start_line_digest, header_0_digest, header_1_digest],
             ciphertext_digest: mock_ct_digest
         }, ["step_out"]);
@@ -113,30 +108,21 @@ describe("HTTP Verification", async () => {
     });
 
     it("witness: http_response_plaintext, two headers, order does not matter", async () => {
-        // Get all the hashes we need
-        let data_digest = PolynomialDigest(http_response_plaintext, mock_ct_digest, BigInt(0));
-
-        // Compute the HTTP info digest
-        let start_line_digest = PolynomialDigest(http_start_line, mock_ct_digest, BigInt(0));
-        let start_line_digest_hashed = poseidon1([start_line_digest]);
-        let header_0_digest = PolynomialDigest(http_header_0, mock_ct_digest, BigInt(0));
-        let header_0_digest_hashed = poseidon1([header_0_digest]);
-        let header_1_digest = PolynomialDigest(http_header_1, mock_ct_digest, BigInt(0));
-        let header_1_digest_hashed = poseidon1([header_1_digest]);
-        let body_digest = PolynomialDigest(http_body, mock_ct_digest, BigInt(0));
-        let body_digest_hashed = poseidon1([body_digest]);
-        // Use `modAdd` to get back a number between 0 and PRIME
-        let output_difference = modAdd(body_digest_hashed - start_line_digest_hashed - header_0_digest_hashed - header_1_digest_hashed - data_digest, BigInt(0));
+        // For this specific test, we need these registers set
+        step_in[4] = start_line_digest_hashed + header_0_digest_hashed + header_1_digest_hashed;
+        step_in[5] = 3; // Total number of matches to expect (sl, h0, h1)
 
         // Run the HTTP circuit
         // POTENTIAL BUG: I didn't get this to work with `expectPass` as it didn't compute `step_out` that way???
         let http_nivc_compute = await HTTPVerification.compute({
-            step_in: 0,  // This doesn't really matter for this test
+            step_in,  // This doesn't really matter for this test
             data: http_response_plaintext,
+            machine_state,
             main_digests: [header_1_digest, start_line_digest, header_0_digest],
             ciphertext_digest: mock_ct_digest
         }, ["step_out"]);
         // I fucking hate circomkit
+        // TODO: need to check more of the assertions
         assert.deepEqual((http_nivc_compute.step_out as BigInt[])[0], output_difference);
     });
 });

--- a/circuits/test/http/verification.test.ts
+++ b/circuits/test/http/verification.test.ts
@@ -174,13 +174,13 @@ describe("HTTP Verification: Split", async () => {
     // dummy[41] = 1;
     // console.log("pow accumulation manual:", PolynomialDigest(dummy, mock_ct_digest, BigInt(0)));
 
+    const mid = http_response_plaintext.length / 2;
+    const [http_response_plaintext_0, http_response_plaintext_1] = [http_response_plaintext.slice(0, mid), http_response_plaintext.slice(mid)];
+
     it("witness: http_response_plaintext, no header", async () => {
         // For this specific test, we need these registers set
         step_in[4] = start_line_digest_hashed;
         step_in[5] = 1; // Total number of matches to expect (sl)
-
-        const mid = http_response_plaintext.length / 2;
-        const [http_response_plaintext_0, http_response_plaintext_1] = [http_response_plaintext.slice(0, mid), http_response_plaintext.slice(mid)];
 
         // Run the HTTP circuit
         // POTENTIAL BUG: I didn't get this to work with `expectPass` as it didn't compute `step_out` that way???
@@ -197,7 +197,6 @@ describe("HTTP Verification: Split", async () => {
         let next_machine_state = [0, 0, 0, 0, 1, 0, 0, BigInt("16202935654388484508586282728137211277659125633297860980774265969941813526293")];
         // let next_machine_state = [0, 0, 0, 0, 1, 0, 0, BigInt("140302555479869")]; // TODO: Only for debuggin!
         let next_step_in = (http_nivc_compute_0.step_out as bigint[]).slice(0, PUBLIC_IO_VARIABLES);
-        next_step_in[6] = BigInt(42); // OVERRIDING
         let http_nivc_compute_1 = await HTTPVerification.compute({
             step_in: next_step_in,
             data: http_response_plaintext_1,
@@ -208,58 +207,87 @@ describe("HTTP Verification: Split", async () => {
         assert.deepEqual((http_nivc_compute_1.step_out as BigInt[])[0], output_difference);
     });
 
-    // it("witness: http_response_plaintext, one header", async () => {
-    //     // For this specific test, we need these registers set
-    //     step_in[4] = start_line_digest_hashed + header_0_digest_hashed;
-    //     step_in[5] = 2; // Total number of matches to expect (sl, h0)
+    it("witness: http_response_plaintext, one header", async () => {
+        // For this specific test, we need these registers set
+        step_in[4] = start_line_digest_hashed + header_0_digest_hashed;
+        step_in[5] = 2; // Total number of matches to expect (sl, h0)
 
-    //     // Run the HTTP circuit
-    //     // POTENTIAL BUG: I didn't get this to work with `expectPass` as it didn't compute `step_out` that way???
-    //     let http_nivc_compute = await HTTPVerification.compute({
-    //         step_in,  // This doesn't really matter for this test
-    //         data: http_response_plaintext,
-    //         machine_state,
-    //         main_digests: [start_line_digest, header_0_digest].concat(Array(1).fill(0)),
-    //         ciphertext_digest: mock_ct_digest
-    //     }, ["step_out"]);
-    //     // I fucking hate circomkit
-    //     assert.deepEqual((http_nivc_compute.step_out as BigInt[])[0], output_difference);
-    // });
+        // Run the HTTP circuit
+        // POTENTIAL BUG: I didn't get this to work with `expectPass` as it didn't compute `step_out` that way???
+        let http_nivc_compute_0 = await HTTPVerification.compute({
+            step_in,  // This doesn't really matter for this test
+            data: http_response_plaintext_0,
+            machine_state,
+            main_digests: [start_line_digest, header_0_digest].concat(Array(1).fill(0)),
+            ciphertext_digest: mock_ct_digest
+        }, ["step_out"]);
 
-    // it("witness: http_response_plaintext, two headers", async () => {
-    //     // For this specific test, we need these registers set
-    //     step_in[4] = start_line_digest_hashed + header_0_digest_hashed + header_1_digest_hashed;
-    //     step_in[5] = 3; // Total number of matches to expect (sl, h0, h1)
+        let next_machine_state = [0, 0, 0, 0, 1, 0, 0, BigInt("16202935654388484508586282728137211277659125633297860980774265969941813526293")];
+        // let next_machine_state = [0, 0, 0, 0, 1, 0, 0, BigInt("140302555479869")]; // TODO: Only for debuggin!
+        let next_step_in = (http_nivc_compute_0.step_out as bigint[]).slice(0, PUBLIC_IO_VARIABLES);
+        let http_nivc_compute_1 = await HTTPVerification.compute({
+            step_in: next_step_in,
+            data: http_response_plaintext_1,
+            machine_state: next_machine_state,
+            main_digests: [start_line_digest, header_0_digest].concat(Array(1).fill(0)),
+            ciphertext_digest: mock_ct_digest
+        }, ["step_out"]);
+        assert.deepEqual((http_nivc_compute_1.step_out as BigInt[])[0], output_difference);
+    });
 
-    //     // Run the HTTP circuit
-    //     // POTENTIAL BUG: I didn't get this to work with `expectPass` as it didn't compute `step_out` that way???
-    //     let http_nivc_compute = await HTTPVerification.compute({
-    //         step_in,  // This doesn't really matter for this test
-    //         data: http_response_plaintext,
-    //         machine_state,
-    //         main_digests: [start_line_digest, header_0_digest, header_1_digest],
-    //         ciphertext_digest: mock_ct_digest
-    //     }, ["step_out"]);
-    //     // I fucking hate circomkit
-    //     assert.deepEqual((http_nivc_compute.step_out as BigInt[])[0], output_difference);
-    // });
+    it("witness: http_response_plaintext, two headers", async () => {
+        // For this specific test, we need these registers set
+        step_in[4] = start_line_digest_hashed + header_0_digest_hashed + header_1_digest_hashed;
+        step_in[5] = 3; // Total number of matches to expect (sl, h0, h1)
 
-    // it("witness: http_response_plaintext, two headers, order does not matter", async () => {
-    //     // For this specific test, we need these registers set
-    //     step_in[4] = start_line_digest_hashed + header_0_digest_hashed + header_1_digest_hashed;
-    //     step_in[5] = 3; // Total number of matches to expect (sl, h0, h1)
+        // Run the HTTP circuit
+        // POTENTIAL BUG: I didn't get this to work with `expectPass` as it didn't compute `step_out` that way???
+        let http_nivc_compute_0 = await HTTPVerification.compute({
+            step_in,  // This doesn't really matter for this test
+            data: http_response_plaintext_0,
+            machine_state,
+            main_digests: [start_line_digest, header_0_digest, header_1_digest],
+            ciphertext_digest: mock_ct_digest
+        }, ["step_out"]);
 
-    //     // Run the HTTP circuit
-    //     // POTENTIAL BUG: I didn't get this to work with `expectPass` as it didn't compute `step_out` that way???
-    //     let http_nivc_compute = await HTTPVerification.compute({
-    //         step_in,  // This doesn't really matter for this test
-    //         data: http_response_plaintext,
-    //         machine_state,
-    //         main_digests: [header_1_digest, start_line_digest, header_0_digest],
-    //         ciphertext_digest: mock_ct_digest
-    //     }, ["step_out"]);
-    //     // I fucking hate circomkit
-    //     // TODO: need to check more of the assertions
-    //     assert.deepEqual((http_nivc_compute.step_out as BigInt[])[0], output_difference);
-    // });
+        let next_machine_state = [0, 0, 0, 0, 1, 0, 0, BigInt("16202935654388484508586282728137211277659125633297860980774265969941813526293")];
+        // let next_machine_state = [0, 0, 0, 0, 1, 0, 0, BigInt("140302555479869")]; // TODO: Only for debuggin!
+        let next_step_in = (http_nivc_compute_0.step_out as bigint[]).slice(0, PUBLIC_IO_VARIABLES);
+        let http_nivc_compute_1 = await HTTPVerification.compute({
+            step_in: next_step_in,
+            data: http_response_plaintext_1,
+            machine_state: next_machine_state,
+            main_digests: [start_line_digest, header_0_digest, header_1_digest],
+            ciphertext_digest: mock_ct_digest
+        }, ["step_out"]);
+        assert.deepEqual((http_nivc_compute_1.step_out as BigInt[])[0], output_difference);
+    });
+
+    it("witness: http_response_plaintext, two headers, order does not matter", async () => {
+        // For this specific test, we need these registers set
+        step_in[4] = start_line_digest_hashed + header_0_digest_hashed + header_1_digest_hashed;
+        step_in[5] = 3; // Total number of matches to expect (sl, h0, h1)
+
+        // Run the HTTP circuit
+        // POTENTIAL BUG: I didn't get this to work with `expectPass` as it didn't compute `step_out` that way???
+        let http_nivc_compute_0 = await HTTPVerification.compute({
+            step_in,  // This doesn't really matter for this test
+            data: http_response_plaintext_0,
+            machine_state,
+            main_digests: [header_1_digest, start_line_digest, header_0_digest],
+            ciphertext_digest: mock_ct_digest
+        }, ["step_out"]);
+
+        let next_machine_state = [0, 0, 0, 0, 1, 0, 0, BigInt("16202935654388484508586282728137211277659125633297860980774265969941813526293")];
+        // let next_machine_state = [0, 0, 0, 0, 1, 0, 0, BigInt("140302555479869")]; // TODO: Only for debuggin!
+        let next_step_in = (http_nivc_compute_0.step_out as bigint[]).slice(0, PUBLIC_IO_VARIABLES);
+        let http_nivc_compute_1 = await HTTPVerification.compute({
+            step_in: next_step_in,
+            data: http_response_plaintext_1,
+            machine_state: next_machine_state,
+            main_digests: [header_1_digest, start_line_digest, header_0_digest],
+            ciphertext_digest: mock_ct_digest
+        }, ["step_out"]);
+        assert.deepEqual((http_nivc_compute_1.step_out as BigInt[])[0], output_difference);
+    });
 });

--- a/circuits/test/http/verification.test.ts
+++ b/circuits/test/http/verification.test.ts
@@ -1,6 +1,7 @@
 import { circomkit, WitnessTester, PolynomialDigest, http_response_plaintext, http_start_line, http_header_0, http_header_1, http_body, modAdd, PUBLIC_IO_VARIABLES } from "../common";
 import { assert } from "chai";
 import { poseidon1 } from "poseidon-lite";
+import { SignalValueType } from "snarkjs";
 
 // HTTP/1.1 200 OK
 // content-type: application/json; charset=utf-8
@@ -35,7 +36,7 @@ describe("HTTP Verification", async () => {
     const mock_ct_digest = poseidon1([69]);
 
     // Used across tests
-    let machine_state = Array(6).fill(0);
+    let machine_state = Array(8).fill(0);
     machine_state[0] = 1; // Sets the parsing start to 1
     let step_in = Array(PUBLIC_IO_VARIABLES).fill(0);
     step_in[3] = 1; // This would be the PD of the machine state given 1 is in the x^0 coeff
@@ -51,7 +52,7 @@ describe("HTTP Verification", async () => {
     let header_1_digest = PolynomialDigest(http_header_1, mock_ct_digest, BigInt(0));
     let header_1_digest_hashed = poseidon1([header_1_digest]);
     let body_digest = PolynomialDigest(http_body, mock_ct_digest, BigInt(0));
-    let output_difference = modAdd(-plaintext_digest, BigInt(0)); // TODO: need to add body_digest
+    let output_difference = modAdd(body_digest - plaintext_digest, BigInt(0));
 
     it("witness: http_response_plaintext, no header", async () => {
         // For this specific test, we need these registers set
@@ -125,4 +126,140 @@ describe("HTTP Verification", async () => {
         // TODO: need to check more of the assertions
         assert.deepEqual((http_nivc_compute.step_out as BigInt[])[0], output_difference);
     });
+});
+
+describe("HTTP Verification: Split", async () => {
+    let HTTPVerification: WitnessTester<["step_in", "data", "machine_state", "main_digests", "ciphertext_digest"], ["step_out"]>;
+    before(async () => {
+        HTTPVerification = await circomkit.WitnessTester("http_nivc", {
+            file: "http/verification",
+            template: "HTTPVerification",
+            params: [DATA_BYTES / 2, MAX_NUMBER_OF_HEADERS, PUBLIC_IO_VARIABLES]
+        });
+    });
+    const mock_ct_digest = poseidon1([69]);
+    // const mock_ct_digest = BigInt(2); // TODO: only for debugging!!!
+
+    // Used across tests
+    let machine_state = Array(8).fill(0);
+    machine_state[0] = 1; // Sets the parsing start to 1
+    let step_in = Array(PUBLIC_IO_VARIABLES).fill(0);
+    step_in[3] = 1; // This would be the PD of the machine state given 1 is in the x^0 coeff
+
+    // Get all the hashes we need
+    let plaintext_digest = PolynomialDigest(http_response_plaintext, mock_ct_digest, BigInt(0));
+
+    // Compute the HTTP info digest
+    let start_line_digest = PolynomialDigest(http_start_line, mock_ct_digest, BigInt(0));
+    let start_line_digest_hashed = poseidon1([start_line_digest]);
+    let header_0_digest = PolynomialDigest(http_header_0, mock_ct_digest, BigInt(0));
+    let header_0_digest_hashed = poseidon1([header_0_digest]);
+    let header_1_digest = PolynomialDigest(http_header_1, mock_ct_digest, BigInt(0));
+    let header_1_digest_hashed = poseidon1([header_1_digest]);
+    let body_digest = PolynomialDigest(http_body, mock_ct_digest, BigInt(0));
+    let output_difference = modAdd(body_digest - plaintext_digest, BigInt(0));
+
+    let plaintext_digest_0 = PolynomialDigest(http_response_plaintext.slice(0, 160), mock_ct_digest, BigInt(0));
+    let plaintext_digest_1 = PolynomialDigest(http_response_plaintext.slice(160), mock_ct_digest, BigInt(160));
+    console.log("outer plaintext_digest_0: ", plaintext_digest_0);
+    console.log("outer plaintext_digest_1: ", plaintext_digest_1);
+
+    let body_digest_0 = PolynomialDigest(http_body.slice(0, 42), mock_ct_digest, BigInt(0));
+    let body_digest_1 = PolynomialDigest(http_body.slice(42), mock_ct_digest, BigInt(42));
+    console.log("outer body_digest_0: ", body_digest_0);
+    console.log("outer body_digest_1: ", body_digest_1);
+    // console.log(body_digest);
+    // console.log(modAdd(body_digest_0, body_digest_1));
+    // let dummy = Array(42).fill(0);
+    // dummy[41] = 1;
+    // console.log("pow accumulation manual:", PolynomialDigest(dummy, mock_ct_digest, BigInt(0)));
+
+    it("witness: http_response_plaintext, no header", async () => {
+        // For this specific test, we need these registers set
+        step_in[4] = start_line_digest_hashed;
+        step_in[5] = 1; // Total number of matches to expect (sl)
+
+        const mid = http_response_plaintext.length / 2;
+        const [http_response_plaintext_0, http_response_plaintext_1] = [http_response_plaintext.slice(0, mid), http_response_plaintext.slice(mid)];
+
+        // Run the HTTP circuit
+        // POTENTIAL BUG: I didn't get this to work with `expectPass` as it didn't compute `step_out` that way???
+        let http_nivc_compute_0 = await HTTPVerification.compute({
+            step_in,
+            data: http_response_plaintext_0,
+            machine_state,
+            main_digests: [start_line_digest].concat(Array(2).fill(0)),
+            ciphertext_digest: mock_ct_digest
+        }, ["step_out"]);
+        // I fucking hate circomkit
+        // assert.deepEqual((http_nivc_compute.step_out as BigInt[])[0], output_difference);
+
+        let next_machine_state = [0, 0, 0, 0, 1, 0, 0, BigInt("16202935654388484508586282728137211277659125633297860980774265969941813526293")];
+        // let next_machine_state = [0, 0, 0, 0, 1, 0, 0, BigInt("140302555479869")]; // TODO: Only for debuggin!
+        let next_step_in = (http_nivc_compute_0.step_out as bigint[]).slice(0, PUBLIC_IO_VARIABLES);
+        next_step_in[6] = BigInt(42); // OVERRIDING
+        let http_nivc_compute_1 = await HTTPVerification.compute({
+            step_in: next_step_in,
+            data: http_response_plaintext_1,
+            machine_state: next_machine_state,
+            main_digests: [start_line_digest].concat(Array(2).fill(0)),
+            ciphertext_digest: mock_ct_digest
+        }, ["step_out"]);
+        assert.deepEqual((http_nivc_compute_1.step_out as BigInt[])[0], output_difference);
+    });
+
+    // it("witness: http_response_plaintext, one header", async () => {
+    //     // For this specific test, we need these registers set
+    //     step_in[4] = start_line_digest_hashed + header_0_digest_hashed;
+    //     step_in[5] = 2; // Total number of matches to expect (sl, h0)
+
+    //     // Run the HTTP circuit
+    //     // POTENTIAL BUG: I didn't get this to work with `expectPass` as it didn't compute `step_out` that way???
+    //     let http_nivc_compute = await HTTPVerification.compute({
+    //         step_in,  // This doesn't really matter for this test
+    //         data: http_response_plaintext,
+    //         machine_state,
+    //         main_digests: [start_line_digest, header_0_digest].concat(Array(1).fill(0)),
+    //         ciphertext_digest: mock_ct_digest
+    //     }, ["step_out"]);
+    //     // I fucking hate circomkit
+    //     assert.deepEqual((http_nivc_compute.step_out as BigInt[])[0], output_difference);
+    // });
+
+    // it("witness: http_response_plaintext, two headers", async () => {
+    //     // For this specific test, we need these registers set
+    //     step_in[4] = start_line_digest_hashed + header_0_digest_hashed + header_1_digest_hashed;
+    //     step_in[5] = 3; // Total number of matches to expect (sl, h0, h1)
+
+    //     // Run the HTTP circuit
+    //     // POTENTIAL BUG: I didn't get this to work with `expectPass` as it didn't compute `step_out` that way???
+    //     let http_nivc_compute = await HTTPVerification.compute({
+    //         step_in,  // This doesn't really matter for this test
+    //         data: http_response_plaintext,
+    //         machine_state,
+    //         main_digests: [start_line_digest, header_0_digest, header_1_digest],
+    //         ciphertext_digest: mock_ct_digest
+    //     }, ["step_out"]);
+    //     // I fucking hate circomkit
+    //     assert.deepEqual((http_nivc_compute.step_out as BigInt[])[0], output_difference);
+    // });
+
+    // it("witness: http_response_plaintext, two headers, order does not matter", async () => {
+    //     // For this specific test, we need these registers set
+    //     step_in[4] = start_line_digest_hashed + header_0_digest_hashed + header_1_digest_hashed;
+    //     step_in[5] = 3; // Total number of matches to expect (sl, h0, h1)
+
+    //     // Run the HTTP circuit
+    //     // POTENTIAL BUG: I didn't get this to work with `expectPass` as it didn't compute `step_out` that way???
+    //     let http_nivc_compute = await HTTPVerification.compute({
+    //         step_in,  // This doesn't really matter for this test
+    //         data: http_response_plaintext,
+    //         machine_state,
+    //         main_digests: [header_1_digest, start_line_digest, header_0_digest],
+    //         ciphertext_digest: mock_ct_digest
+    //     }, ["step_out"]);
+    //     // I fucking hate circomkit
+    //     // TODO: need to check more of the assertions
+    //     assert.deepEqual((http_nivc_compute.step_out as BigInt[])[0], output_difference);
+    // });
 });

--- a/circuits/utils/hash.circom
+++ b/circuits/utils/hash.circom
@@ -51,6 +51,38 @@ template DataHasher(DATA_BYTES) {
     out <== hashes[DATA_BYTES \ 16];
 }
 
+// TODO: Lazy so i made a new template when we should probably just reuse the other and refactor elsewhere
+template DataHasherWithSeed(DATA_BYTES) {
+    // TODO: add this assert back after witnesscalc supports
+    // assert(DATA_BYTES % 16 == 0);
+    signal input seed;
+    signal input in[DATA_BYTES];
+    signal output out;
+
+    signal not_to_hash[DATA_BYTES \ 16];
+    signal option_hash[DATA_BYTES \ 16];
+    signal hashes[DATA_BYTES \ 16 + 1];
+    signal isPadding[DATA_BYTES];
+    hashes[0] <== seed;
+    for(var i = 0 ; i < DATA_BYTES \ 16 ; i++) {
+        var packedInput = 0;
+        var isPaddedChunk = 0;
+        for(var j = 0 ; j < 16 ; j++) {
+            /*
+            If in[16 * i + j] is ever -1 we get `isPadding[16 * i + j] === 1` and since we add this
+            we get zero which does not change `packedInput`.
+            */
+            isPadding[16 * i + j] <== IsEqual()([in[16 * i + j], -1]);
+            isPaddedChunk          += isPadding[16 * i + j];
+            packedInput            += (in[16 * i + j] + isPadding[16 * i + j]) * 2**(8*j);
+        }
+        not_to_hash[i] <== IsEqual()([isPaddedChunk, 16]);
+        option_hash[i] <== Poseidon(2)([hashes[i],packedInput]);
+        hashes[i+1]    <== not_to_hash[i] * (hashes[i] - option_hash[i]) + option_hash[i]; // same as: (1 - not_to_hash[i]) * option_hash[i] + not_to_hash[i] * hash[i];
+    }
+    out <== hashes[DATA_BYTES \ 16];
+}
+
 template PolynomialDigest(N) {
     signal input bytes[N];
     signal input polynomial_input;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-prover-circuits",
   "description": "ZK Circuits for WebProofs",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
@lonerapier 

This PR accomplishes the following:
- Makes `PlaintextAuthentication` handle folding across byte boundaries properly. To see this, run `npx mocha -g "padded plaintext: split"`
- Makes `HTTPVerification` handle folding across byte boundaries properly including accumulating the body digest.  To see this, run `npx mocha -g "HTTP Verification: Split"`

### Some Notes:
I have added a few more IO variables just because I want to solve this problem and I don't believe 11 total is far worse than 9. I know we can reduce these in a later revision.

With that said, note that in `PlaintextAuthentication` I use: 
```
step_out[10] <== part_ciphertext_digest;
```
to house the running `DataHasher`'d state of the ciphertext components we get from plaintext encryption in-circuit.

I also inserted as `step_in[6]` the running counter for the http body as this was also needed.

### Other Remarks:
You note that we are not checking for 1 time match exactly for headers. Correct. I think this is okay actually because we are checking concretely that we are using the correct plaintext, so I don't really see how this is easily gameable. In the future, we can prevent this, but I am not worried about this for now.  

### TODOs
- For combining req/resp we need to have all the headers and both start lines put into a single array for a test. I don't think the logic in `HTTPVerification` actually changes though.